### PR TITLE
Restrict public API: add client serializers, lock down stats endpoints

### DIFF
--- a/inveterate/serializers.py
+++ b/inveterate/serializers.py
@@ -251,6 +251,13 @@ class InventorySerializer(serializers.ModelSerializer):
         fields = '__all__'
 
 
+class InventorySerializerClient(serializers.ModelSerializer):
+    class Meta:
+        model = models.Inventory
+        fields = ('id', 'plan', 'quantity')
+        read_only_fields = fields
+
+
 class IPSerializer(serializers.ModelSerializer):
     class Meta:
         model = models.IP
@@ -262,11 +269,25 @@ class AppProfileSerializer(serializers.ModelSerializer):
         fields = '__all__'
 
 
+class AppProfileSerializerClient(serializers.ModelSerializer):
+    class Meta:
+        model = models.AppProfile
+        fields = ('id', 'name', 'description', 'min_cores', 'min_ram', 'min_disk', 'created')
+        read_only_fields = fields
+
+
 class TemplateSerializer(serializers.ModelSerializer):
     class Meta:
         model = models.Template
         fields = '__all__'
         read_only_fields = ('status', 'status_msg')
+
+
+class TemplateSerializerClient(serializers.ModelSerializer):
+    class Meta:
+        model = models.Template
+        fields = ('id', 'name', 'type', 'status', 'created')
+        read_only_fields = fields
 
     def create(self, validated_data):
         template = super().create(validated_data)

--- a/inveterate/viewsets/resource.py
+++ b/inveterate/viewsets/resource.py
@@ -35,6 +35,11 @@ class InventoryViewSet(DynamicPageModelViewSet):
     queryset = models.Inventory.objects.order_by('pk')
     serializer_class = serializers.InventorySerializer
 
+    def get_serializer_class(self):
+        if self.request.user.is_staff:
+            return serializers.InventorySerializer
+        return serializers.InventorySerializerClient
+
     @action(methods=['post'], detail=False)
     def calculate(self, request):
         task = calculate_inventory.delay()
@@ -80,7 +85,7 @@ class PlanViewSet(DynamicPageModelViewSet):
     search_fields = ['name']
     ordering_fields = ['id', 'name', 'size', 'ram', 'cores', 'created']
 
-    @action(methods=['get'], detail=False)
+    @action(methods=['get'], detail=False, permission_classes=[IsAdminUser])
     def stats(self, request, pk=None):
         stats = {
             'plans': {
@@ -100,6 +105,11 @@ class AppProfileViewSet(DynamicPageModelViewSet):
     search_fields = ['name']
     ordering_fields = ['id', 'name', 'created']
 
+    def get_serializer_class(self):
+        if self.request.user.is_staff:
+            return serializers.AppProfileSerializer
+        return serializers.AppProfileSerializerClient
+
 
 class TemplateViewSet(DynamicPageModelViewSet):
     permission_classes = [IsAdminUser | ReadOnlyAnonymous]
@@ -110,7 +120,12 @@ class TemplateViewSet(DynamicPageModelViewSet):
     search_fields = ['name']
     ordering_fields = ['id', 'name', 'type', 'created']
 
-    @action(methods=['get'], detail=False)
+    def get_serializer_class(self):
+        if self.request.user.is_staff:
+            return serializers.TemplateSerializer
+        return serializers.TemplateSerializerClient
+
+    @action(methods=['get'], detail=False, permission_classes=[IsAdminUser])
     def stats(self, request, pk=None):
         stats = {
             'templates': {


### PR DESCRIPTION
Strip internal fields (file, source_url, node, cloud_init) from Template, AppProfile, and Inventory responses for non-staff users. Restrict plan/template stats endpoints to admin only.